### PR TITLE
CBQE-8924 : Create test_system_continuous_backup directory on NFS mount for continuous backup tests

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -97,7 +97,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup archive location
     file:
@@ -105,7 +105,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup s3 location
     file:
@@ -113,7 +113,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup gcp location
     file:
@@ -121,7 +121,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup azure location
     file:
@@ -129,7 +129,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: set /data to be owned by couchbase
     shell: "chown -R couchbase:couchbase /data"
@@ -382,7 +382,7 @@
         state: directory
         owner: couchbase
         group: couchbase
-        mode: 777
+        mode: '0777'
       when:
         - nfs_enabled
         - not is_nfs_server
@@ -393,7 +393,7 @@
         state: directory
         owner: couchbase
         group: couchbase
-        mode: 777
+        mode: '0777'
       when:
         - nfs_enabled
         - not is_nfs_server

--- a/install.yml
+++ b/install.yml
@@ -361,6 +361,14 @@
         - nfs_enabled
         - not is_nfs_server
 
+    - name: NFS CLIENT | Clean up test continuous backup directory
+      file:
+        path: "{{ mount_point }}/test_system_continuous_backup"
+        state: absent
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
     - name: NFS CLIENT | Installation complete
       debug:
         msg: "NFS client configured - {{ nfs_server_ip }}:{{ nfs_share }} mounted at {{ mount_point }}"
@@ -371,6 +379,17 @@
     - name: create backup archive location
       file:
         path: "{{ mount_point }}/test_system_backup"
+        state: directory
+        owner: couchbase
+        group: couchbase
+        mode: 777
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: create continuous backup archive location
+      file:
+        path: "{{ mount_point }}/test_system_continuous_backup"
         state: directory
         owner: couchbase
         group: couchbase


### PR DESCRIPTION
- Adding a new directory for continuous backup
- Cleaning up existing continuous backup
- Similar to setup/cleanup for backuprestore system tests