### PR TITLE
CBQE-8891 : Add pipeline support to distribute S3/Azure Storage access keys to provisioned nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,9 @@ pipeline {
 
         string(name: 'SGW_INSTALL_URL', defaultValue: '', description: 'Sync Gateway install URL')
         booleanParam(name: 'WITH_SGW', defaultValue: false, description: 'Include Sync Gateway')
-        
-        
+        booleanParam(name: 'NFS_TEST', defaultValue: false, description: 'Fetch NFS server from pool (poolId=nfs_server)')
+
+
         string(name: 'SCALE', defaultValue: '1', description: 'Scale parameter for sequoia')
         string(name: 'REPEAT', defaultValue: '1', description: 'Repeat parameter for sequoia')
         string(name: 'DURATION', defaultValue: '604800', description: 'Test duration in seconds')
@@ -116,17 +117,17 @@ pipeline {
                             export GO111MODULE=on
                             cd /opt/godev/src/github.com/couchbaselabs/sequoia
                             go version
-                            
+
                             # Verify go.mod exists (should be in repository)
                             if [ ! -f go.mod ]; then
                                 echo "ERROR: go.mod not found in repository. Please ensure the branch has go.mod checked in."
                                 exit 1
                             fi
-                            
+
                             # Downgrade to compatible versions that work with Go 1.21
                             go get github.com/fsouza/go-dockerclient@v1.9.0
                             go get github.com/docker/docker@v20.10.24+incompatible
-                            
+
                             go mod tidy
                             go build -o sequoia
                         '''
@@ -140,7 +141,7 @@ pipeline {
             steps {
                 script {
                     echo ">>> SKIP_INSTALL parameter value: ${params.SKIP_INSTALL}"
-                    
+
                     withCredentials([
                         usernamePassword(credentialsId: 'root', usernameVariable: 'SSH_USERNAME', passwordVariable: 'SSH_PASSWORD'),
                         usernamePassword(credentialsId: 'qe_db_cluster', usernameVariable: 'CONFIG_USERNAME', passwordVariable: 'CONFIG_PASSWORD')
@@ -160,7 +161,8 @@ pipeline {
                                         --sgw-build ${params.SGW_BUILD} \
                                         --cb-install-url '${params.CB_INSTALL_URL}' \
                                         --sgw-install-url '${params.SGW_INSTALL_URL}' \
-                                        --with-sgw ${params.WITH_SGW}
+                                        --with-sgw ${params.WITH_SGW} \
+                                        --nfs-test ${params.NFS_TEST}
                                 """
                             }
                             echo ">>> Deployment completed successfully"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
                     withCredentials([
                         usernamePassword(credentialsId: 'root', usernameVariable: 'SSH_USERNAME', passwordVariable: 'SSH_PASSWORD'),
                         usernamePassword(credentialsId: 'qe_db_cluster', usernameVariable: 'CONFIG_USERNAME', passwordVariable: 'CONFIG_PASSWORD'),
-                        usernamePassword(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_S3_ACCESS_KEYS', usernameVariable: 'AWS_ACCESS_KEY_ID', passwordVariable: 'AWS_SECRET_ACCESS_KEY')
+                        [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_S3_ACCESS_KEYS', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
                     ]) {
                         if (!params.SKIP_INSTALL) {
                             echo ">>> Starting Couchbase deployment..."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,9 @@ pipeline {
                     withCredentials([
                         usernamePassword(credentialsId: 'root', usernameVariable: 'SSH_USERNAME', passwordVariable: 'SSH_PASSWORD'),
                         usernamePassword(credentialsId: 'qe_db_cluster', usernameVariable: 'CONFIG_USERNAME', passwordVariable: 'CONFIG_PASSWORD'),
-                        [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_S3_ACCESS_KEYS', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                        [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_S3_ACCESS_KEYS', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+                        usernamePassword(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_AZURE_ACCESS_KEYS', usernameVariable: 'AZURE_STORAGE_ACCOUNT', passwordVariable: 'AZURE_STORAGE_KEY'),
+                        string(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_AZURE_ENDPOINT', variable: 'AZURE_STORAGE_ENDPOINT')
                     ]) {
                         if (!params.SKIP_INSTALL) {
                             echo ">>> Starting Couchbase deployment..."
@@ -156,6 +158,9 @@ pipeline {
                                     export ANSIBLE_SSH_PASSWORD="$SSH_PASSWORD"
                                     export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
                                     export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
+                                    export AZURE_STORAGE_ACCOUNT='${AZURE_STORAGE_ACCOUNT}'
+                                    export AZURE_STORAGE_KEY='${AZURE_STORAGE_KEY}'
+                                    export AZURE_STORAGE_ENDPOINT='${AZURE_STORAGE_ENDPOINT}'
                                     ./deploy.sh \
                                         --cb-pool-id ${params.COMPONENT} \
                                         --cb-version ${params.CB_VERSION} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,8 @@ pipeline {
 
                     withCredentials([
                         usernamePassword(credentialsId: 'root', usernameVariable: 'SSH_USERNAME', passwordVariable: 'SSH_PASSWORD'),
-                        usernamePassword(credentialsId: 'qe_db_cluster', usernameVariable: 'CONFIG_USERNAME', passwordVariable: 'CONFIG_PASSWORD')
+                        usernamePassword(credentialsId: 'qe_db_cluster', usernameVariable: 'CONFIG_USERNAME', passwordVariable: 'CONFIG_PASSWORD'),
+                        usernamePassword(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_S3_ACCESS_KEYS', usernameVariable: 'AWS_ACCESS_KEY_ID', passwordVariable: 'AWS_SECRET_ACCESS_KEY')
                     ]) {
                         if (!params.SKIP_INSTALL) {
                             echo ">>> Starting Couchbase deployment..."
@@ -153,6 +154,8 @@ pipeline {
                                     export CONFIG_PASSWORD='${CONFIG_PASSWORD}'
                                     export SSH_PASSWORD='${SSH_PASSWORD}'
                                     export ANSIBLE_SSH_PASSWORD="$SSH_PASSWORD"
+                                    export AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}'
+                                    export AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}'
                                     ./deploy.sh \
                                         --cb-pool-id ${params.COMPONENT} \
                                         --cb-version ${params.CB_VERSION} \

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,12 +19,14 @@ SCOPE="_default"
 COLLECTION="system_longevity_machines"
 CB_POOL_ID=""
 WITH_SGW=false
+NFS_TEST=false
 
 # Manual IP options
 CB_HOSTS=""
 CB_HOSTS_FILE=""
 SGW_HOSTS=""
 SGW_HOSTS_FILE=""
+NFS_HOST=""
 
 # Common options
 CB_VERSION="7.6.8"
@@ -66,19 +68,21 @@ INPUT OPTIONS (Choose one):
     --bucket NAME                   Bucket (default: QE-server-pool)
     --scope NAME                    Scope (default: _default)
     --collection NAME               Collection (default: system_longevity_machines)
-  
+    --nfs-test true|false           Fetch NFS server from pool (poolId=nfs_server, default: false)
+
   Manual IPs:
     --cb-hosts "IP1 IP2"            Space-separated CB IPs
     --cb-hosts-file FILE            File with CB IPs (one per line)
     --sgw-hosts "IP1 IP2"           Space-separated SGW IPs
     --sgw-hosts-file FILE           File with SGW IPs (one per line)
+    --nfs-host IP                   NFS server IP (manual)
 
 VERSION OPTIONS:
     --cb-version VERSION            CB Server version (default: 7.6.8)
     --cb-build BUILD                CB Server build (default: 7151)
     --cb-flavor FLAVOR              CB Server flavor (auto-detected from version, can override)
     --cb-install-url URL            Custom CB install URL (overrides version/build/flavor)
-    
+
     --with-sgw true|false           Also install Sync Gateway on hosts tagged with 'sgw' (default: false)
     --sgw-version VERSION           SGW version (default: 3.3.0)
     --sgw-build BUILD               SGW build (default: 271)
@@ -90,20 +94,20 @@ BEHAVIOR OPTIONS:
     --hosts-file PATH               Custom hosts file path (default: ansible/hosts)
     --cb-group-name NAME            CB group name (default: couchbase_servers)
     --sgw-group-name NAME           SGW group name (default: sync_gateways)
-    
+
     -h, --help                      Show this help message
 
 EXAMPLES:
     # CB only (excludes hosts tagged with "sgw")
     CONFIG_PASSWORD="pass" $0 --cb-pool-id longevity_cluster_2
-    
+
     # CB + SGW (also deploys to hosts tagged with "sgw")
     CONFIG_PASSWORD="pass" $0 --cb-pool-id longevity_cluster_2 --with-sgw true
-    
+
     # With custom versions
     CONFIG_PASSWORD="pass" $0 --cb-pool-id longevity_cluster_2 --with-sgw true \
       --cb-version 7.6.8 --cb-build 7151
-    
+
     # From Manual IPs
     $0 --cb-hosts "172.23.105.1 172.23.105.2"
 
@@ -124,11 +128,13 @@ while [[ $# -gt 0 ]]; do
         --collection) COLLECTION="$2"; shift 2 ;;
         --cb-pool-id) CB_POOL_ID="$2"; shift 2 ;;
         --with-sgw) WITH_SGW="$2"; shift 2 ;;
+        --nfs-test) NFS_TEST="$2"; shift 2 ;;
         # Manual IP options
         --cb-hosts) CB_HOSTS="$2"; shift 2 ;;
         --cb-hosts-file) CB_HOSTS_FILE="$2"; shift 2 ;;
         --sgw-hosts) SGW_HOSTS="$2"; shift 2 ;;
         --sgw-hosts-file) SGW_HOSTS_FILE="$2"; shift 2 ;;
+        --nfs-host) NFS_HOST="$2"; shift 2 ;;
         # Common options
         --cb-version) CB_VERSION="$2"; shift 2 ;;
         --cb-build) CB_BUILD="$2"; shift 2 ;;
@@ -154,7 +160,7 @@ done
 if [[ -z "$CB_FLAVOR" ]]; then
     # Default flavor
     CB_FLAVOR="sherlock"
-    
+
     # Determine flavor based on version
     if echo "$CB_VERSION" | grep -q "^6\.5"; then
         CB_FLAVOR="mad-hatter"
@@ -177,7 +183,7 @@ if [[ -z "$CB_FLAVOR" ]]; then
     elif echo "$CB_VERSION" | grep -q "^8\.1"; then
         CB_FLAVOR="totoro"
     fi
-    
+
     echo -e "${GREEN}Auto-detected CB_FLAVOR: $CB_FLAVOR (from version $CB_VERSION)${NC}"
 fi
 
@@ -236,7 +242,7 @@ if [[ "$USE_QE_CONFIG" == true ]]; then
     # Step 1a: Fetch master node IP first
     echo -e "${YELLOW}Step 1: Fetching master node IP from QE Config Server...${NC}"
     echo ""
-    
+
 MASTER_IP=$(./fetch_hosts.sh \
     --config-server "$CONFIG_SERVER" \
     --config-port "$CONFIG_PORT" \
@@ -253,7 +259,7 @@ MASTER_IP=$(./fetch_hosts.sh \
     else
         echo -e "${GREEN}Found master node: $MASTER_IP${NC}"
     fi
-    
+
     # Step 1b: Fetch remaining CB IPs
     echo ""
     echo -e "${YELLOW}Fetching remaining Couchbase Server IPs...${NC}"
@@ -274,17 +280,17 @@ CB_IPS=$(./fetch_hosts.sh \
         echo -e "${RED}Error: Failed to fetch CB IPs${NC}"
         exit 1
     fi
-    
+
     # Create provider YAML file with CB IPs (master first)
     TEMP_YAML="provider.yaml"
     echo "---" > "$TEMP_YAML"
     echo "" >> "$TEMP_YAML"
-    
+
     # Add master node first if found
     if [[ -n "$MASTER_IP" ]]; then
         echo "$MASTER_IP" >> "$TEMP_YAML"
     fi
-    
+
     # Add remaining CB IPs (excluding master if it was in the list)
     for ip in $CB_IPS; do
         if [[ "$ip" != "$MASTER_IP" ]]; then
@@ -300,7 +306,7 @@ CB_IPS=$(./fetch_hosts.sh \
         echo ""
         echo -e "${YELLOW}Step 2: Fetching Sync Gateway IPs (hosts tagged with 'sgw')...${NC}"
         echo ""
-        
+
         SGW_IPS=$(./fetch_hosts.sh \
             --config-server "$CONFIG_SERVER" \
             --config-port "$CONFIG_PORT" \
@@ -311,7 +317,7 @@ CB_IPS=$(./fetch_hosts.sh \
             --collection "$COLLECTION" \
             --pool-id "$CB_POOL_ID" \
             --query-type sgw)
-        
+
         if [[ -z "$SGW_IPS" ]]; then
             echo -e "${YELLOW}Warning: No SGW IPs found (no hosts tagged with 'sgw' in pool)${NC}"
         else
@@ -322,29 +328,60 @@ CB_IPS=$(./fetch_hosts.sh \
             echo -e "${GREEN}Added SGW IPs to $TEMP_YAML${NC}"
         fi
     fi
+
+    # Fetch NFS server if nfs_test is enabled
+    NFS_SERVER_IP=""
+    if [[ "$NFS_TEST" == "true" ]]; then
+        echo ""
+        echo -e "${YELLOW}Fetching NFS server IP (poolId=nfs_server)...${NC}"
+        echo ""
+
+        NFS_SERVER_IP=$(./fetch_hosts.sh \
+            --config-server "$CONFIG_SERVER" \
+            --config-port "$CONFIG_PORT" \
+            --config-user "$CONFIG_USER" \
+            --config-pass "$CONFIG_PASS" \
+            --bucket "$BUCKET" \
+            --scope "$SCOPE" \
+            --collection "$COLLECTION" \
+            --pool-id "nfs_server" \
+            --query-type nfs)
+
+        if [[ -z "$NFS_SERVER_IP" ]]; then
+            echo -e "${YELLOW}Warning: No NFS server found (poolId=nfs_server)${NC}"
+        else
+            echo -e "${GREEN}Found NFS server: $NFS_SERVER_IP${NC}"
+            # Add NFS server to temporary YAML file with nfs_server: prefix
+            echo "nfs_server:$NFS_SERVER_IP" >> "$TEMP_YAML"
+            echo -e "${GREEN}Added NFS server to $TEMP_YAML${NC}"
+        fi
+    fi
 else
     # Using manual IPs
     echo -e "${YELLOW}Step 1: Using provided IPs...${NC}"
     echo ""
-    
+
     # Get CB IPs from file or command line
     if [[ -n "$CB_HOSTS_FILE" ]]; then
         CB_HOSTS=$(grep -v '^#' "$CB_HOSTS_FILE" | grep -v '^[[:space:]]*$' | tr '\n' ' ')
     fi
     CB_IPS="$CB_HOSTS"
-    
+
     # Get SGW IPs from file or command line
     SGW_IPS=""
     if [[ -n "$SGW_HOSTS_FILE" ]]; then
         SGW_HOSTS=$(grep -v '^#' "$SGW_HOSTS_FILE" | grep -v '^[[:space:]]*$' | tr '\n' ' ')
     fi
     SGW_IPS="$SGW_HOSTS"
-    
+
+    # Get NFS server IP from command line
+    NFS_SERVER_IP="$NFS_HOST"
+
     if [[ -z "$CB_IPS" ]]; then
         echo -e "${RED}Error: No IPs provided${NC}"
         exit 1
     fi
-    
+
     # Create provider YAML file with manual IPs
     TEMP_YAML="provider.yaml"
     echo "---" > "$TEMP_YAML"
@@ -353,13 +390,17 @@ else
         echo "$ip" >> "$TEMP_YAML"
     done
     echo "" >> "$TEMP_YAML"
-    
+
     if [[ -n "$SGW_IPS" ]]; then
         for ip in $SGW_IPS; do
             echo "syncgateway:$ip" >> "$TEMP_YAML"
         done
     fi
-    
+
+    if [[ -n "$NFS_SERVER_IP" ]]; then
+        echo "nfs_server:$NFS_SERVER_IP" >> "$TEMP_YAML"
+    fi
+
     echo -e "${GREEN}Created provider IP list: $TEMP_YAML${NC}"
 fi
 
@@ -415,7 +456,7 @@ if [[ -n "$SGW_IPS" ]]; then
     INSTALL_CMD="$INSTALL_CMD -e \"sgw_target_hosts=$SGW_GROUP_NAME\""
     INSTALL_CMD="$INSTALL_CMD -e \"SGW_VER=$SGW_VERSION\""
     INSTALL_CMD="$INSTALL_CMD -e \"SGW_BUILD_NO=$SGW_BUILD\""
-    
+
     # Add custom SGW install URL if provided
     if [[ -n "$SGW_INSTALL_URL" ]]; then
         INSTALL_CMD="$INSTALL_CMD -e \"SGW_URL=$SGW_INSTALL_URL\""
@@ -452,6 +493,9 @@ echo "Summary:"
 echo "  CB IPs: $CB_IPS"
 if [[ -n "$SGW_IPS" ]]; then
     echo "  SGW IPs: $SGW_IPS"
+fi
+if [[ -n "$NFS_SERVER_IP" ]]; then
+    echo "  NFS Server: $NFS_SERVER_IP"
 fi
 echo "  CB Version: $CB_VERSION-$CB_BUILD ($CB_FLAVOR)"
 if [[ -n "$SGW_IPS" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -472,6 +472,12 @@ if [[ "$SKIP_UNINSTALL" == true ]]; then
     INSTALL_CMD="$INSTALL_CMD -e \"PERFORM_SGW_UNINSTALL=false\""
 fi
 
+# Add NFS server IP if provided (enables NFS client setup on CB nodes)
+if [[ -n "$NFS_SERVER_IP" ]]; then
+    INSTALL_CMD="$INSTALL_CMD -e \"nfs_server=$NFS_SERVER_IP\""
+    echo -e "${GREEN}NFS client setup enabled - server: $NFS_SERVER_IP${NC}"
+fi
+
 echo "Running: $INSTALL_CMD"
 echo ""
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -478,6 +478,13 @@ if [[ -n "$NFS_SERVER_IP" ]]; then
     echo -e "${GREEN}NFS client setup enabled - server: $NFS_SERVER_IP${NC}"
 fi
 
+# Add S3 credentials if provided (for backup/restore tests)
+if [[ -n "$AWS_ACCESS_KEY_ID" && -n "$AWS_SECRET_ACCESS_KEY" ]]; then
+    INSTALL_CMD="$INSTALL_CMD -e \"aws_access_key_id=$AWS_ACCESS_KEY_ID\""
+    INSTALL_CMD="$INSTALL_CMD -e \"aws_secret_access_key=$AWS_SECRET_ACCESS_KEY\""
+    echo -e "${GREEN}S3 credentials will be configured on target nodes${NC}"
+fi
+
 echo "Running: $INSTALL_CMD"
 echo ""
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -485,6 +485,16 @@ if [[ -n "$AWS_ACCESS_KEY_ID" && -n "$AWS_SECRET_ACCESS_KEY" ]]; then
     echo -e "${GREEN}S3 credentials will be configured on target nodes${NC}"
 fi
 
+# Add Azure credentials if provided (for backup/restore tests)
+if [[ -n "$AZURE_STORAGE_ACCOUNT" && -n "$AZURE_STORAGE_KEY" ]]; then
+    INSTALL_CMD="$INSTALL_CMD -e \"azure_storage_account=$AZURE_STORAGE_ACCOUNT\""
+    INSTALL_CMD="$INSTALL_CMD -e \"azure_storage_key=$AZURE_STORAGE_KEY\""
+    if [[ -n "$AZURE_STORAGE_ENDPOINT" ]]; then
+        INSTALL_CMD="$INSTALL_CMD -e \"azure_storage_endpoint=$AZURE_STORAGE_ENDPOINT\""
+    fi
+    echo -e "${GREEN}Azure credentials will be configured on target nodes${NC}"
+fi
+
 echo "Running: $INSTALL_CMD"
 echo ""
 

--- a/fetch_hosts.sh
+++ b/fetch_hosts.sh
@@ -46,12 +46,12 @@ QUERY OPTIONS:
     --scope NAME                    Scope name (default: _default)
     --collection NAME               Collection name (default: system_longevity_machines)
     --pool-id ID                    Pool ID to query (REQUIRED)
-    --query-type TYPE               Query type: cb or sgw (default: cb)
+    --query-type TYPE               Query type: cb, sgw, master, or nfs (default: cb)
 
 OUTPUT OPTIONS:
     --output-file FILE              Save IPs to file (one per line)
     --output-format FORMAT          Output format: list or file (default: list)
-    
+
     -h, --help                      Show this help message
 
 EXAMPLES:
@@ -122,9 +122,12 @@ if [[ "$QUERY_TYPE" == "master" ]]; then
 elif [[ "$QUERY_TYPE" == "sgw" ]]; then
     # Query for Sync Gateway hosts: pool_id AND "sgw" tag
     QUERY="SELECT ipaddr FROM \`${BUCKET}\`.\`${SCOPE}\`.\`${COLLECTION}\` WHERE \"${POOL_ID}\" IN poolId AND \"sgw\" IN poolId AND state=\"available\""
+elif [[ "$QUERY_TYPE" == "nfs" ]]; then
+    # Query for NFS server: pool_id only (no sgw exclusion)
+    QUERY="SELECT ipaddr FROM \`${BUCKET}\`.\`${SCOPE}\`.\`${COLLECTION}\` WHERE \"${POOL_ID}\" IN poolId AND \"nfs_server\" IN poolId AND state=\"available\""
 else
     # Query for Couchbase Server hosts: pool_id but NOT "sgw" tag
-    QUERY="SELECT ipaddr FROM \`${BUCKET}\`.\`${SCOPE}\`.\`${COLLECTION}\` WHERE \"${POOL_ID}\" IN poolId AND \"sgw\" NOT IN poolId AND state=\"available\""
+    QUERY="SELECT ipaddr FROM \`${BUCKET}\`.\`${SCOPE}\`.\`${COLLECTION}\` WHERE \"${POOL_ID}\" IN poolId AND \"sgw\" NOT IN poolId AND \"nfs_server\" NOT IN poolId AND state=\"available\""
 fi
 
 # Build config server URL

--- a/install.yml
+++ b/install.yml
@@ -261,3 +261,92 @@
         - perform_install | default(true)
         - sgw_port_check is succeeded
 
+# Install NFS Client on all CB nodes (if nfs_server is provided)
+# Usage: Add -e "nfs_server=<NFS_SERVER_IP>" to enable NFS client setup
+- hosts: "{{ target_hosts }}"
+  gather_facts: yes
+  vars:
+    nfs_share: "{{ NFS_SHARE | default('/data') }}"
+    mount_point: "{{ MOUNT_POINT | default('/mnt/nfs_data') }}"
+    nfs_server_ip: "{{ nfs_server | default('') }}"
+  remote_user: root
+  tasks:
+    - name: NFS CLIENT | Check if NFS setup is enabled
+      set_fact:
+        nfs_enabled: "{{ nfs_server_ip | length > 0 }}"
+        is_nfs_server: "{{ ansible_host == nfs_server_ip or inventory_hostname == nfs_server_ip }}"
+
+    - name: NFS CLIENT | Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: NFS CLIENT | Install NFS client packages
+      apt:
+        name: nfs-common
+        state: present
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: NFS CLIENT | Verify NFS exports from server
+      shell: "showmount -e {{ nfs_server_ip }}"
+      register: nfs_exports
+      ignore_errors: true
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: NFS CLIENT | Display available NFS exports
+      debug:
+        msg: "{{ nfs_exports.stdout_lines }}"
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+        - nfs_exports is succeeded
+
+    - name: NFS CLIENT | Create mount point directory
+      file:
+        path: "{{ mount_point }}"
+        state: directory
+        mode: '0755'
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: NFS CLIENT | Mount NFS share
+      mount:
+        src: "{{ nfs_server_ip }}:{{ nfs_share }}"
+        path: "{{ mount_point }}"
+        fstype: nfs
+        opts: defaults,_netdev
+        state: mounted
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: NFS CLIENT | Verify mount
+      shell: "df -h | grep nfs"
+      register: mount_verify
+      ignore_errors: true
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: NFS CLIENT | Display mount status
+      debug:
+        msg: "{{ mount_verify.stdout_lines }}"
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+        - mount_verify is succeeded
+
+    - name: NFS CLIENT | Installation complete
+      debug:
+        msg: "NFS client configured - {{ nfs_server_ip }}:{{ nfs_share }} mounted at {{ mount_point }}"
+      when:
+        - nfs_enabled
+        - not is_nfs_server

--- a/install.yml
+++ b/install.yml
@@ -203,6 +203,34 @@
         msg: "S3 credentials configured in /etc/profile.d/s3_credentials.sh"
       when: s3_enabled
 
+# Set Azure credentials as environment variables (if provided)
+- hosts: "{{ target_hosts }}"
+  gather_facts: no
+  vars:
+    azure_account: "{{ azure_storage_account | default('') }}"
+    azure_key: "{{ azure_storage_key | default('') }}"
+    azure_endpoint: "{{ azure_storage_endpoint | default('') }}"
+  remote_user: root
+  tasks:
+    - name: AZURE CREDENTIALS | Check if Azure setup is enabled
+      set_fact:
+        azure_enabled: "{{ azure_account | length > 0 and azure_key | length > 0 }}"
+
+    - name: AZURE CREDENTIALS | Create environment file for Azure credentials
+      copy:
+        dest: /etc/profile.d/azure_credentials.sh
+        content: |
+          export AZURE_STORAGE_ACCOUNT="{{ azure_account }}"
+          export AZURE_STORAGE_KEY="{{ azure_key }}"
+          export AZURE_STORAGE_ENDPOINT="{{ azure_endpoint }}"
+        mode: "0644"
+      when: azure_enabled
+
+    - name: AZURE CREDENTIALS | Configuration complete
+      debug:
+        msg: "Azure credentials configured in /etc/profile.d/azure_credentials.sh"
+      when: azure_enabled
+
 # Install Sync Gateway (if sgw_target_hosts is provided)
 - hosts: "{{ sgw_target_hosts | default('none') }}"
   gather_facts: no

--- a/install.yml
+++ b/install.yml
@@ -177,6 +177,32 @@
   - name: wait for install done
     wait_for: port=8091 delay=10
 
+# Set S3 credentials as environment variables (if provided)
+- hosts: "{{ target_hosts }}"
+  gather_facts: no
+  vars:
+    s3_access_key: "{{ aws_access_key_id | default('') }}"
+    s3_secret_key: "{{ aws_secret_access_key | default('') }}"
+  remote_user: root
+  tasks:
+    - name: S3 CREDENTIALS | Check if S3 setup is enabled
+      set_fact:
+        s3_enabled: "{{ s3_access_key | length > 0 and s3_secret_key | length > 0 }}"
+
+    - name: S3 CREDENTIALS | Create environment file for S3 credentials
+      copy:
+        dest: /etc/profile.d/s3_credentials.sh
+        content: |
+          export AWS_ACCESS_KEY_ID="{{ s3_access_key }}"
+          export AWS_SECRET_ACCESS_KEY="{{ s3_secret_key }}"
+        mode: "0644"
+      when: s3_enabled
+
+    - name: S3 CREDENTIALS | Configuration complete
+      debug:
+        msg: "S3 credentials configured in /etc/profile.d/s3_credentials.sh"
+      when: s3_enabled
+
 # Install Sync Gateway (if sgw_target_hosts is provided)
 - hosts: "{{ sgw_target_hosts | default('none') }}"
   gather_facts: no

--- a/install.yml
+++ b/install.yml
@@ -97,7 +97,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup archive location
     file:
@@ -105,7 +105,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup s3 location
     file:
@@ -113,7 +113,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup gcp location
     file:
@@ -121,7 +121,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: create backup azure location
     file:
@@ -129,7 +129,7 @@
       state: directory
       owner: couchbase
       group: couchbase
-      mode: 777
+      mode: '0777'
   
   - name: set /data to be owned by couchbase
     shell: "chown -R couchbase:couchbase /data"
@@ -314,6 +314,7 @@
       apt:
         update_cache: yes
         cache_valid_time: 3600
+      ignore_errors: True
       when:
         - nfs_enabled
         - not is_nfs_server
@@ -382,6 +383,16 @@
       file:
         path: "{{ mount_point }}/test_system_backup"
         state: absent
+      run_once: true
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: NFS CLIENT | Clean up test continuous backup directory
+      file:
+        path: "{{ mount_point }}/test_system_continuous_backup"
+        state: absent
+      run_once: true
       when:
         - nfs_enabled
         - not is_nfs_server
@@ -399,7 +410,20 @@
         state: directory
         owner: couchbase
         group: couchbase
-        mode: 777
+        mode: '0777'
+      run_once: true
+      when:
+        - nfs_enabled
+        - not is_nfs_server
+
+    - name: create continuous backup archive location
+      file:
+        path: "{{ mount_point }}/test_system_continuous_backup"
+        state: directory
+        owner: couchbase
+        group: couchbase
+        mode: '0777'
+      run_once: true
       when:
         - nfs_enabled
         - not is_nfs_server


### PR DESCRIPTION
## Summary
     Adds support for distributing cloud storage credentials (AWS S3, Azure) to all nodes during
     deployment, enabling backup/restore system tests that require cloud storage access.

Refer : [CBQE-8891](https://jira.issues.couchbase.com/browse/CBQE-8891)

## Changes

### AWS S3 Support
     - **Jenkinsfile**: Added `BACKUP_RESTORE_SYSTEMTEST_S3_ACCESS_KEYS` credential binding
     - **deploy.sh**: Pass AWS credentials to ansible-playbook
     - **install.yml**: Create `/etc/profile.d/s3_credentials.sh` with `AWS_ACCESS_KEY_ID` and
     `AWS_SECRET_ACCESS_KEY`

### Azure Storage Support
     - **Jenkinsfile**: Added `BACKUP_RESTORE_SYSTEMTEST_AZURE_ACCESS_KEYS` (account/key) and
     `BACKUP_RESTORE_SYSTEMTEST_AZURE_ENDPOINT` (secret text) credential bindings
     - **deploy.sh**: Pass Azure credentials to ansible-playbook
     - **install.yml**: Create `/etc/profile.d/azure_credentials.sh` with `AZURE_STORAGE_ACCOUNT`,
     `AZURE_STORAGE_KEY`, and `AZURE_STORAGE_ENDPOINT`

## Usage
     Cloud storage credentials are automatically provisioned when the Jenkins job runs. After deployment, any
     user logging into the target nodes will have the credentials available in their environment.

[CBQE-8891]: https://couchbasecloud.atlassian.net/browse/CBQE-8891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ