### PR TITLE
CBQE-8891 : Add pipeline support to distribute GCP Storage access keys to provisioned nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,7 +147,8 @@ pipeline {
                         usernamePassword(credentialsId: 'qe_db_cluster', usernameVariable: 'CONFIG_USERNAME', passwordVariable: 'CONFIG_PASSWORD'),
                         [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_S3_ACCESS_KEYS', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
                         usernamePassword(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_AZURE_ACCESS_KEYS', usernameVariable: 'AZURE_STORAGE_ACCOUNT', passwordVariable: 'AZURE_STORAGE_KEY'),
-                        string(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_AZURE_ENDPOINT', variable: 'AZURE_STORAGE_ENDPOINT')
+                        string(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_AZURE_ENDPOINT', variable: 'AZURE_STORAGE_ENDPOINT'),
+                        file(credentialsId: 'BACKUP_RESTORE_SYSTEMTEST_GCP_JSON', variable: 'GCP_SERVICE_ACCOUNT_FILE')
                     ]) {
                         if (!params.SKIP_INSTALL) {
                             echo ">>> Starting Couchbase deployment..."
@@ -161,6 +162,7 @@ pipeline {
                                     export AZURE_STORAGE_ACCOUNT='${AZURE_STORAGE_ACCOUNT}'
                                     export AZURE_STORAGE_KEY='${AZURE_STORAGE_KEY}'
                                     export AZURE_STORAGE_ENDPOINT='${AZURE_STORAGE_ENDPOINT}'
+                                    export GCP_SERVICE_ACCOUNT_FILE='${GCP_SERVICE_ACCOUNT_FILE}'
                                     ./deploy.sh \
                                         --cb-pool-id ${params.COMPONENT} \
                                         --cb-version ${params.CB_VERSION} \

--- a/deploy.sh
+++ b/deploy.sh
@@ -495,6 +495,12 @@ if [[ -n "$AZURE_STORAGE_ACCOUNT" && -n "$AZURE_STORAGE_KEY" ]]; then
     echo -e "${GREEN}Azure credentials will be configured on target nodes${NC}"
 fi
 
+# Add GCP credentials if provided (for backup/restore tests)
+if [[ -n "$GCP_SERVICE_ACCOUNT_FILE" ]]; then
+    INSTALL_CMD="$INSTALL_CMD -e \"gcp_service_account_file=$GCP_SERVICE_ACCOUNT_FILE\""
+    echo -e "${GREEN}GCP credentials will be configured on target nodes${NC}"
+fi
+
 echo "Running: $INSTALL_CMD"
 echo ""
 

--- a/install.yml
+++ b/install.yml
@@ -231,6 +231,44 @@
         msg: "Azure credentials configured in /etc/profile.d/azure_credentials.sh"
       when: azure_enabled
 
+# Set GCP credentials (if provided)
+- hosts: "{{ target_hosts }}"
+  gather_facts: no
+  vars:
+    gcp_key_file: "{{ gcp_service_account_file | default('') }}"
+  remote_user: root
+  tasks:
+    - name: GCP CREDENTIALS | Check if GCP setup is enabled
+      set_fact:
+        gcp_enabled: "{{ gcp_key_file | length > 0 }}"
+
+    - name: GCP CREDENTIALS | Create directory for GCP credentials
+      file:
+        path: /etc/google
+        state: directory
+        mode: "0755"
+      when: gcp_enabled
+
+    - name: GCP CREDENTIALS | Copy GCP service account key file
+      copy:
+        src: "{{ gcp_key_file }}"
+        dest: /etc/google/service_account.json
+        mode: "0600"
+      when: gcp_enabled
+
+    - name: GCP CREDENTIALS | Create environment file for GCP credentials
+      copy:
+        dest: /etc/profile.d/gcp_credentials.sh
+        content: |
+          export GOOGLE_APPLICATION_CREDENTIALS="/etc/google/service_account.json"
+        mode: "0644"
+      when: gcp_enabled
+
+    - name: GCP CREDENTIALS | Configuration complete
+      debug:
+        msg: "GCP credentials configured in /etc/google/service_account.json"
+      when: gcp_enabled
+
 # Install Sync Gateway (if sgw_target_hosts is provided)
 - hosts: "{{ sgw_target_hosts | default('none') }}"
   gather_facts: no


### PR DESCRIPTION
## Summary
     Extends the provisioning pipeline to distribute GCP service account credentials to target nodes, enabling backup/restore
     system tests against GCP storage. Follows the same pattern as the existing AWS S3 and Azure credential distribution.

Refer : [CBQE-8891](https://jira.issues.couchbase.com/browse/CBQE-8891)

## Changes

 - Jenkinsfile: Binds the BACKUP_RESTORE_SYSTEMTEST_GCP_JSON Jenkins Secret file credential and exports the temp file path as GCP_SERVICE_ACCOUNT_FILE into the deploy environment.
 - deploy.sh: If GCP_SERVICE_ACCOUNT_FILE is set, passes the file path to Ansible via -e gcp_service_account_file=....
 - install.yml: New play that copies the service account JSON to /etc/google/service_account.json (mode 0600) on all target nodes and writes /etc/profile.d/gcp_credentials.sh exporting GOOGLE_APPLICATION_CREDENTIALS to that path.

## Usage
     Cloud storage credentials are automatically provisioned when the Jenkins job runs. After deployment, any
     user logging into the target nodes will have the credentials available in their environment.

## Credential setup required
     A Jenkins Secret file credential named BACKUP_RESTORE_SYSTEMTEST_GCP_JSON must exist containing the GCP
     service account JSON key before this pipeline step will activate. If absent or empty, the GCP play
     is a no-op (consistent with how AWS/Azure behave).

[CBQE-8891]: https://couchbasecloud.atlassian.net/browse/CBQE-8891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ