### PR TITLE
Split NFS_TEST into NFS_LONGEVITY_TEST and NFS_COMPONENT_TEST to isolate parallel test runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,8 @@ pipeline {
 
         string(name: 'SGW_INSTALL_URL', defaultValue: '', description: 'Sync Gateway install URL')
         booleanParam(name: 'WITH_SGW', defaultValue: false, description: 'Include Sync Gateway')
-        booleanParam(name: 'NFS_TEST', defaultValue: false, description: 'Fetch NFS server from pool (poolId=nfs_server)')
+        booleanParam(name: 'NFS_LONGEVITY_TEST', defaultValue: false, description: 'Fetch NFS server from pool for longevity tests (poolId=nfs_server)')
+        booleanParam(name: 'NFS_COMPONENT_TEST', defaultValue: false, description: 'Fetch NFS server from pool for component tests (poolId=nfs_server)')
 
 
         string(name: 'SCALE', defaultValue: '1', description: 'Scale parameter for sequoia')
@@ -172,7 +173,8 @@ pipeline {
                                         --cb-install-url '${params.CB_INSTALL_URL}' \
                                         --sgw-install-url '${params.SGW_INSTALL_URL}' \
                                         --with-sgw ${params.WITH_SGW} \
-                                        --nfs-test ${params.NFS_TEST}
+                                        --nfs-longevity-test ${params.NFS_LONGEVITY_TEST} \
+                                        --nfs-component-test ${params.NFS_COMPONENT_TEST}
                                 """
                             }
                             echo ">>> Deployment completed successfully"

--- a/deploy.sh
+++ b/deploy.sh
@@ -159,6 +159,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Enforce mutual exclusivity of NFS test modes
+if [[ "$NFS_LONGEVITY_TEST" == "true" && "$NFS_COMPONENT_TEST" == "true" ]]; then
+    echo -e "${RED}Error: NFS_LONGEVITY_TEST and NFS_COMPONENT_TEST cannot both be true. Enable only one.${NC}"
+    exit 1
+fi
+
 # Auto-compute CB_FLAVOR from CB_VERSION if not explicitly set
 if [[ -z "$CB_FLAVOR" ]]; then
     # Default flavor

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,8 @@ SCOPE="_default"
 COLLECTION="system_longevity_machines"
 CB_POOL_ID=""
 WITH_SGW=false
-NFS_TEST=false
+NFS_LONGEVITY_TEST=false
+NFS_COMPONENT_TEST=false
 
 # Manual IP options
 CB_HOSTS=""
@@ -68,7 +69,8 @@ INPUT OPTIONS (Choose one):
     --bucket NAME                   Bucket (default: QE-server-pool)
     --scope NAME                    Scope (default: _default)
     --collection NAME               Collection (default: system_longevity_machines)
-    --nfs-test true|false           Fetch NFS server from pool (poolId=nfs_server, default: false)
+    --nfs-longevity-test true|false  Fetch NFS server from pool for longevity tests (poolId=nfs_server, default: false)
+    --nfs-component-test true|false  Fetch NFS server from pool for component tests (poolId=nfs_server, default: false)
 
   Manual IPs:
     --cb-hosts "IP1 IP2"            Space-separated CB IPs
@@ -128,7 +130,8 @@ while [[ $# -gt 0 ]]; do
         --collection) COLLECTION="$2"; shift 2 ;;
         --cb-pool-id) CB_POOL_ID="$2"; shift 2 ;;
         --with-sgw) WITH_SGW="$2"; shift 2 ;;
-        --nfs-test) NFS_TEST="$2"; shift 2 ;;
+        --nfs-longevity-test) NFS_LONGEVITY_TEST="$2"; shift 2 ;;
+        --nfs-component-test) NFS_COMPONENT_TEST="$2"; shift 2 ;;
         # Manual IP options
         --cb-hosts) CB_HOSTS="$2"; shift 2 ;;
         --cb-hosts-file) CB_HOSTS_FILE="$2"; shift 2 ;;
@@ -329,9 +332,9 @@ CB_IPS=$(./fetch_hosts.sh \
         fi
     fi
 
-    # Fetch NFS server if nfs_test is enabled
+    # Fetch NFS server if either NFS test mode is enabled
     NFS_SERVER_IP=""
-    if [[ "$NFS_TEST" == "true" ]]; then
+    if [[ "$NFS_LONGEVITY_TEST" == "true" || "$NFS_COMPONENT_TEST" == "true" ]]; then
         echo ""
         echo -e "${YELLOW}Fetching NFS server IP (poolId=nfs_server)...${NC}"
         echo ""
@@ -475,6 +478,12 @@ fi
 # Add NFS server IP if provided (enables NFS client setup on CB nodes)
 if [[ -n "$NFS_SERVER_IP" ]]; then
     INSTALL_CMD="$INSTALL_CMD -e \"nfs_server=$NFS_SERVER_IP\""
+    if [[ "$NFS_LONGEVITY_TEST" == "true" ]]; then
+        INSTALL_CMD="$INSTALL_CMD -e \"nfs_longevity_test=true\""
+    fi
+    if [[ "$NFS_COMPONENT_TEST" == "true" ]]; then
+        INSTALL_CMD="$INSTALL_CMD -e \"nfs_component_test=true\""
+    fi
     echo -e "${GREEN}NFS client setup enabled - server: $NFS_SERVER_IP${NC}"
 fi
 

--- a/install.yml
+++ b/install.yml
@@ -365,6 +365,8 @@
     nfs_share: "{{ NFS_SHARE | default('/data') }}"
     mount_point: "{{ MOUNT_POINT | default('/mnt/nfs_data') }}"
     nfs_server_ip: "{{ nfs_server | default('') }}"
+    nfs_longevity_test_enabled: "{{ nfs_longevity_test | default(false) | bool }}"
+    nfs_component_test_enabled: "{{ nfs_component_test | default(false) | bool }}"
   remote_user: root
   tasks:
     - name: NFS CLIENT | Skip play when NFS setup is not enabled
@@ -453,6 +455,7 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_component_test_enabled
 
     - name: NFS CLIENT | Clean up longevity backup directory
       file:
@@ -462,6 +465,7 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_longevity_test_enabled
 
     - name: NFS CLIENT | Clean up test continuous backup directory
       file:
@@ -471,6 +475,7 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_component_test_enabled
 
     - name: NFS CLIENT | Clean up longevity continuous backup directory
       file:
@@ -480,6 +485,7 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_longevity_test_enabled
 
     - name: NFS CLIENT | Installation complete
       debug:
@@ -499,6 +505,7 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_component_test_enabled
 
     - name: create continuous backup archive location
       file:
@@ -511,6 +518,7 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_component_test_enabled
 
     - name: create backup archive location for longevity
       file:
@@ -523,6 +531,7 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_longevity_test_enabled
 
     - name: create continuous backup archive location for longevity
       file:
@@ -535,3 +544,4 @@
       when:
         - nfs_enabled
         - not is_nfs_server
+        - nfs_longevity_test_enabled


### PR DESCRIPTION
<h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Longevity and component tests can run concurrently on the same NFS mount. The single <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NFS_TEST</code> flag caused <strong>all</strong> backup directories to be wiped and recreated on every setup — meaning a longevity run could destroy a component test's archive mid-flight and vice versa, silently corrupting in-progress tests.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Split <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NFS_TEST</code> into two scoped flags so each test type only manages its own directories:</p>
Flag | Directories managed
-- | --
NFS_LONGEVITY_TEST | test_longevity_backup, test_longevity_continuous_backup
NFS_COMPONENT_TEST | test_system_backup, test_system_continuous_backup

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Both flags still trigger the same NFS server fetch from the pool and client mount setup — only the directory cleanup/create lifecycle is now isolated.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>Jenkinsfile</strong>: Replaced<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NFS_TEST</code><span> </span>boolean param with<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NFS_LONGEVITY_TEST</code><span> </span>and<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NFS_COMPONENT_TEST</code>; updated the<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">deploy.sh</code><span> </span>invocation accordingly</li><li><strong>deploy.sh</strong>: Replaced<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">--nfs-test</code><span> </span>with<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">--nfs-longevity-test</code><span> </span>/<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">--nfs-component-test</code>; NFS server fetch triggers if either flag is set; passes the active flag to Ansible so<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">install.yml</code><span> </span>knows which directories to touch</li><li><strong>install.yml</strong>: Added<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">nfs_longevity_test_enabled</code><span> </span>/<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">nfs_component_test_enabled</code><span> </span>vars; gated each cleanup and create task on the appropriate flag</li></ul>